### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mp_hand_gesture/keras_metadata.pb -text


### PR DESCRIPTION
This PR closes #3 
Changes made:
Added .gitattributes which stops `mp_hand_gesture/keras_metadata.pb`, LF(Unix-style) getting replaced by CRLF(Windows-style) everytime Git touches it.